### PR TITLE
301 moved permanently

### DIFF
--- a/src/webtsainterface/static/js/data.js
+++ b/src/webtsainterface/static/js/data.js
@@ -32,20 +32,20 @@ define('data', ['jquery'], function() {
             return newval;
         });
 
-		$.getJSON(window.location.pathname + "api/v1/facets?limit=0").done(function(data) {
+		$.getJSON(window.location.pathname + "api/v1/facets/?limit=0").done(function(data) {
             self.facets = data.objects;
             extendFacets();
             dataLoader.loadedData++;
             $(document).trigger(facetsLoaded);
         });
 
-		$.getJSON(window.location.pathname + "api/v1/sites?limit=0").done(function(data) {
+		$.getJSON(window.location.pathname + "api/v1/sites/?limit=0").done(function(data) {
             self.sites = data.objects;
             dataLoader.loadedData++;
             $(document).trigger(sitesLoaded);
         });
 
-        $.getJSON(window.location.pathname + "api/v1/dataseries?limit=0").done(function(data) {
+        $.getJSON(window.location.pathname + "api/v1/dataseries/?limit=0").done(function(data) {
             self.dataseries = data.objects;
             extendDataseries();
             extendFilters();


### PR DESCRIPTION
The URIs used to access the API were missing a slash. Resolving to the correct URL resulted in a ~60ms page load delay.